### PR TITLE
[RSpec]リクエストのテスト更新

### DIFF
--- a/app/controllers/shippings_controller.rb
+++ b/app/controllers/shippings_controller.rb
@@ -23,7 +23,7 @@ class ShippingsController < ApplicationController
       redirect_to customers_shippings_path
       flash[:create] = 'NEW SHIPPING ! '
     else
-      @shippings = Shipping.where(customer_id: current_customer.id)
+      @shippings = Shipping.where(customer_id: current_customer.id).page(params[:page]).per(10)
       flash.now[:notice] = '正しく入力ができていません。もう一度入力して下さい'
       render 'shippings/index'
     end

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -10,7 +10,7 @@
     	<span class="form-title" style="font-size:15px">注文情報</span>
         <table class="table table-bordered">
             <tr>
-              <th class="table-active" style="width: 20%">注文日</th>
+              <th class="table-active" style="width: 40%">注文日</th>
               <td><%= @order.created_at.strftime('%Y/%m/%d')%>
               </td>
             </tr>

--- a/spec/factories/cooking.rb
+++ b/spec/factories/cooking.rb
@@ -1,7 +1,5 @@
 FactoryBot.define do
   factory :cooking do
-    recipe_id {1}
     content {"test-content"}
-    association :recipe
   end
 end

--- a/spec/factories/product.rb
+++ b/spec/factories/product.rb
@@ -1,9 +1,7 @@
 FactoryBot.define do
   factory :product do
-    genre_id {1}
     name {"test-name"}
     price {100}
     introduction {"test-introduction"}
-    association :genre
   end
 end

--- a/spec/models/cart_item_spec.rb
+++ b/spec/models/cart_item_spec.rb
@@ -3,7 +3,8 @@ require 'rails_helper'
 RSpec.describe CartItem, type: :model do
 	before(:each) do
 		@customer = create(:customer)
-		@product = create(:product)
+		@genre = create(:genre)
+		@product = create(:product, genre_id: @genre.id)
 	  	@cart_item = build(:cart_item, customer_id: @customer.id, product_id: @product.id)
  	end
 

--- a/spec/models/cooking_spec.rb
+++ b/spec/models/cooking_spec.rb
@@ -2,7 +2,9 @@ require 'rails_helper'
 
 RSpec.describe Cooking, type: :model do
 	before(:each) do
-	  	@cooking = build(:cooking)
+		@customer = create(:customer)
+		@recipe = create(:recipe, customer_id: @customer.id)
+	  	@cooking = build(:cooking, recipe_id: @recipe.id)
  	end
 
  	it "作り方の作成ができる" do

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -58,7 +58,8 @@ RSpec.describe Customer, type: :model do
   context "レビューメソッド" do
     before do
       @customer = create(:customer)
-      @product = create(:product)
+      @genre = create(:genre)
+      @product = create(:product, genre_id: @genre.id)
     end
     it "既にレビューをしているか" do
       @review = create(:review, customer_id: @customer.id, product_id: @product.id)

--- a/spec/models/order_detail_spec.rb
+++ b/spec/models/order_detail_spec.rb
@@ -3,7 +3,8 @@ require 'rails_helper'
 RSpec.describe OrderDetail, type: :model do
 	before(:each) do
 		@customer = create(:customer)
-		@product = create(:product)
+		@genre = create(:genre)
+		@product = create(:product, genre_id: @genre.id)
 		@order = create(:order, customer_id: @customer.id)
 	  	@order_detail = build(:order_detail, order_id: @order.id, product_id: @product.id)
  	end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 
 RSpec.describe Product, type: :model do
 	before(:each) do
-	  	@product = build(:product)
+		@genre = create(:genre)
+	  	@product = build(:product, genre_id: @genre.id)
  	end
 
  	it "商品の作成ができる" do

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -3,7 +3,8 @@ require 'rails_helper'
 RSpec.describe Review, type: :model do
 	before(:each) do
       @customer = create(:customer)
-      @product = create(:product)
+	  @genre = create(:genre)
+	  @product = create(:product, genre_id: @genre.id)
       @review = create(:review, customer_id: @customer.id, product_id: @product.id)
  	end
 

--- a/spec/requests/cart_items_spec.rb
+++ b/spec/requests/cart_items_spec.rb
@@ -3,12 +3,24 @@ require 'rails_helper'
 RSpec.describe "CartItems", type: :request do
 	before do
 		@customer = create(:customer)
+		@genre = create(:genre)
+		@product = create(:product, genre_id: @genre.id)
 		sign_in @customer
-		@product = create(:product)
 	end
-	it "カート内商品の新規作成ができる" do
+	it "カート内商品の新規作成リクエストが成功する" do
 		post customers_cart_items_path, params: { cart_item: FactoryBot.attributes_for(:cart_item) }
 		expect(response).to have_http_status(302)
+	end
+	it "カート内商品が1件増える" do
+        expect do
+			post customers_cart_items_path, params: { cart_item: FactoryBot.attributes_for(:cart_item, customer_id: @customer.id, product_id: @product.id) }
+        end.to change(CartItem, :count).by(1)
+	end
+
+	it "値が正しくない場合、カート内商品が新規作成されない" do
+        expect do
+          post customers_cart_items_path, params: { cart_item: FactoryBot.attributes_for(:cart_item, count: nil, customer_id: @customer.id, product_id: @product.id) }
+        end.to_not change(CartItem, :count)
 	end
 
 	it "カート内商品の確認画面を表示できる" do
@@ -20,17 +32,39 @@ RSpec.describe "CartItems", type: :request do
 		before do
 			@cart_item = create(:cart_item, customer_id: @customer.id, product_id: @product.id)
 		end
-		it "カート内商品を編集できる" do
+		it "カート内商品の更新リクエストが成功する" do
 			put customers_cart_item_path(@cart_item), params: { cart_item: FactoryBot.attributes_for(:cart_item) }
 			expect(response).to redirect_to cart_item_confirm_path
 		end
-		it "カート内商品を削除できる" do
+		it "カート内商品の個数が更新される" do
+			expect do
+				put customers_cart_item_path(@cart_item), params: { cart_item: FactoryBot.attributes_for(:cart_item, count: 2) }
+			end.to change { CartItem.find(@cart_item.id).count }.from(@cart_item.count).to(2)
+		end
+		it "値が正しくない場合、カート内商品が更新されない" do
+			expect do
+				put customers_cart_item_path(@cart_item), params: { cart_item: FactoryBot.attributes_for(:cart_item, count: nil) }
+			end.to_not change { CartItem.find(@cart_item.id).count }
+		end
+
+		it "カート内商品を削除リクエストが成功する" do
 			delete customers_cart_item_path(@cart_item)
 			expect(response).to redirect_to cart_item_confirm_path
 		end
-		it "カート内商品を全て削除できる" do
+		it "カート内商品が1件減る" do
+	        expect do
+				delete customers_cart_item_path(@cart_item)
+	        end.to change(CartItem, :count).by(-1)
+		end
+		it "カート内商品を全て削除リクエストが成功する" do
 			delete cart_items_destroy_all_path
 			expect(response).to redirect_to cart_item_confirm_path
+		end
+		it "カート内商品が0件になる" do
+	        expect do
+	        	@cart_item_2 = CartItem.create(count: 2, customer_id: @customer.id, product_id: @product.id)
+				delete cart_items_destroy_all_path
+	        end.to change(CartItem, :count).by(-(CartItem.all).count)
 		end
 	end
 end

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -16,6 +16,12 @@ RSpec.describe "Comments", type: :request do
 		end.to change(Comment, :count).by(1)
 	end
 
+	it "値が正しくない場合、コメントの作成に失敗する" do
+		expect do
+			post recipe_comments_path(@recipe), params: { comment: FactoryBot.attributes_for(:comment, content: nil ) }, xhr: true
+		end.to_not change(Comment, :count)
+	end
+
 	context "コメントが必要なリクエスト" do
 		before do
 			@comment = create(:comment, recipe_id: @recipe.id, customer_id: @customer.id)

--- a/spec/requests/cookings_spec.rb
+++ b/spec/requests/cookings_spec.rb
@@ -10,18 +10,49 @@ RSpec.describe "Cookings", type: :request do
 		get edit_recipe_cookings_path(@recipe)
 		expect(response).to have_http_status(200)
 	end
-	it "作り方の新規作成ができる" do
+
+	it "作り方の新規作成リクエストが成功する" do
 		post recipe_cookings_path(@recipe), params: { cooking: FactoryBot.attributes_for(:cooking) }, xhr: true
 		expect(response).to have_http_status(200)
+	end
+	it "作り方が1件増える" do
+        expect do
+			post recipe_cookings_path(@recipe), params: { cooking: FactoryBot.attributes_for(:cooking, recipe_id: @recipe.id) }, xhr: true
+        end.to change(Cooking, :count).by(1)
+	end
+	it "値が正しくない場合、作り方が新規作成されない" do
+		expect do
+			post recipe_cookings_path(@recipe), params: { cooking: FactoryBot.attributes_for(:cooking, recipe_id: @recipe.id, content: nil) }, xhr: true
+		end.to_not change(Cooking, :count)
 	end
 
 	context "作り方が必要なリクエスト" do
 		before do
 			@cooking = create(:cooking, recipe_id: @recipe.id)
 		end
-		it "材料の削除ができる" do
+		it "作り方の更新リクエストが成功する" do
+			put recipe_cooking_path(@cooking, @recipe), params: { cooking: FactoryBot.attributes_for(:cooking, recipe_id: @recipe.id) }, xhr: true
+			expect(response).to have_http_status(200)
+		end
+		it "作り方の更新ができる" do
+			expect do
+				put recipe_cooking_path(@cooking, @recipe), params: { cooking: FactoryBot.attributes_for(:cooking, recipe_id: @recipe.id, content: "update" ) }, xhr: true
+			end.to change { Cooking.find(@cooking.id).content }.from(@cooking.content).to("update")
+		end
+		it "値が正しくない場合、作り方が更新されない" do
+			expect do
+				put recipe_cooking_path(@cooking, @recipe), params: { cooking: FactoryBot.attributes_for(:cooking, recipe_id: @recipe.id, content: nil ) }, xhr: true
+			end.to_not change { Cooking.find(@cooking.id).content }
+		end
+
+		it "作り方の削除リクエストが成功する" do
 			delete recipe_cooking_path(@cooking, @recipe), xhr: true
 			expect(response).to have_http_status(200)
+		end
+		it "作り方が1件減る" do
+	        expect do
+				delete recipe_cooking_path(@cooking, @recipe), xhr: true
+	        end.to change(Cooking, :count).by(-1)
 		end
 	end
 end

--- a/spec/requests/customers_spec.rb
+++ b/spec/requests/customers_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "Customers", type: :request do
 		get customer_path(@customer)
 		expect(response).to have_http_status(200)
 	end
+
 	it "いいねしたレシピの一覧画面を表示できる" do
 		get favorites_path(@customer)
 		expect(response).to have_http_status(200)
@@ -21,17 +22,30 @@ RSpec.describe "Customers", type: :request do
 			get edit_customer_path(@customer)
 			expect(response).to have_http_status(200)
 		end
-		it "顧客情報の更新ができる" do
+		it "顧客情報の更新リクエストが成功する" do
 			put customer_path(@customer), params: { customer: FactoryBot.attributes_for(:customer) }
 			expect(response).to redirect_to customer_path(@customer)
 		end
+		it "顧客情報が更新される" do
+			expect do
+				put customer_path(@customer), params: { customer: FactoryBot.attributes_for(:customer, account_name: "update_name") }
+			end.to change { Customer.find(@customer.id).account_name }.from(@customer.account_name).to("update_name")
+		end
+		it "値が正しくない場合、顧客情報が更新されない" do
+			expect do
+				put customer_path(@customer), params: { customer: FactoryBot.attributes_for(:customer, name: nil) }
+			end.to_not change { Customer.find(@customer.id).account_name }
+		end
+
+
 		it "退会画面が表示できる" do
 			get customers_delete_path
 			expect(response).to have_http_status(200)
 		end
 		it "退会できる" do
-			delete customer_path(@customer)
-			expect(response).to redirect_to root_path
+			expect do
+				delete customer_path(@customer)
+			end.to change { Customer.with_deleted.find(@customer.id).is_active }.from(@customer.is_active).to("退会済")
 		end
 	end
 end

--- a/spec/requests/favorites_spec.rb
+++ b/spec/requests/favorites_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Favorites", type: :request do
 		sign_in @customer
 	end
 
-	it "いいねができる" do
+	it "いいねをするリクエストが成功する" do
 		post recipe_favorites_path(@recipe), xhr: true
 		expect(response).to have_http_status(200)
 	end
@@ -21,7 +21,7 @@ RSpec.describe "Favorites", type: :request do
 		before do
 			post recipe_favorites_path(@recipe), xhr: true
 		end
-		it "いいねを削除できる" do
+		it "いいねを削除するリクエストが成功する" do
 			delete recipe_favorites_path(@recipe), xhr: true
 			expect(response).to have_http_status(200)
 		end

--- a/spec/requests/ingredients_spec.rb
+++ b/spec/requests/ingredients_spec.rb
@@ -10,9 +10,20 @@ RSpec.describe "Ingredients", type: :request do
 		get edit_recipe_ingredients_path(@recipe)
 		expect(response).to have_http_status(200)
 	end
-	it "材料の新規作成ができる" do
+
+	it "材料の新規作成リクエストが成功する" do
 		post recipe_ingredients_path(@recipe), params: { ingredient: FactoryBot.attributes_for(:ingredient) }, xhr: true
 		expect(response).to have_http_status(200)
+	end
+	it "材料が1件増える" do
+        expect do
+			post recipe_ingredients_path(@recipe), params: { ingredient: FactoryBot.attributes_for(:ingredient, recipe_id: @recipe.id) }, xhr: true
+        end.to change(Ingredient, :count).by(1)
+	end
+	it "値が正しくない場合、材料が新規作成されない" do
+		expect do
+			post recipe_ingredients_path(@recipe), params: { ingredient: FactoryBot.attributes_for(:ingredient, recipe_id: @recipe.id, content: nil) }, xhr: true
+		end.to_not change(Ingredient, :count)
 	end
 
 	context "材料が必要なリクエスト" do
@@ -22,6 +33,31 @@ RSpec.describe "Ingredients", type: :request do
 		it "材料の削除ができる" do
 			delete recipe_ingredient_path(@ingredient, @recipe), xhr: true
 			expect(response).to have_http_status(200)
+		end
+
+		it "材料の更新リクエストが成功する" do
+			put recipe_ingredient_path(@ingredient, @recipe), params: { ingredient: FactoryBot.attributes_for(:ingredient, recipe_id: @recipe.id) }, xhr: true
+			expect(response).to have_http_status(200)
+		end
+		it "材料の更新ができる" do
+			expect do
+				put recipe_ingredient_path(@ingredient, @recipe), params: { ingredient: FactoryBot.attributes_for(:ingredient, recipe_id: @recipe.id, content: "update" ) }, xhr: true
+			end.to change { Ingredient.find(@ingredient.id).content }.from(@ingredient.content).to("update")
+		end
+		it "値が正しくない場合、材料が更新されない" do
+			expect do
+				put recipe_ingredient_path(@ingredient, @recipe), params: { ingredient: FactoryBot.attributes_for(:ingredient, recipe_id: @recipe.id, content: nil ) }, xhr: true
+			end.to_not change { Ingredient.find(@ingredient.id).content }
+		end
+
+		it "材料の削除リクエストが成功する" do
+			delete recipe_ingredient_path(@ingredient, @recipe), xhr: true
+			expect(response).to have_http_status(200)
+		end
+		it "材料が1件減る" do
+	        expect do
+				delete recipe_ingredient_path(@ingredient, @recipe), xhr: true
+	        end.to change(Ingredient, :count).by(-1)
 		end
 	end
 end

--- a/spec/requests/orders_spec.rb
+++ b/spec/requests/orders_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe "Orders", type: :request do
 		@customer = create(:customer, name: "test", postcode: "1234567", address: "test", tel: "11122223333" )
 		sign_in @customer
 		@shipping = create(:shipping, customer_id: @customer.id)
-		@product = create(:product)
+		@genre = create(:genre)
+		@product = create(:product, genre_id: @genre.id)
 		@cart_item = create(:cart_item, customer_id: @customer.id, product_id: @product.id)
 	end
 	it "注文の新規作成画面が表示できる" do
@@ -17,10 +18,16 @@ RSpec.describe "Orders", type: :request do
 		expect(response).to have_http_status(200)
 	end
 
-	it "注文の新規作成ができる" do
+	it "注文の新規作成のリクエストが成功する" do
 		post customers_orders_path
-		expect(response).to redirect_to order_confirm_path
+		expect(response).to have_http_status(302)
 	end
+	it "値が正しくない場合、注文が新規作成されない" do
+        expect do
+			post customers_orders_path, params: { order: FactoryBot.attributes_for(:order, customer_id: @customer.id, postcode: 123456) }
+        end.to_not change(Order, :count)
+	end
+
 	it "注文の完了画面が表示できる" do
 		get order_complete_path
 		expect(response).to have_http_status(200)

--- a/spec/requests/products_spec.rb
+++ b/spec/requests/products_spec.rb
@@ -1,12 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe "Products", type: :request do
-	it "商品の一覧画面を表示" do
+	before do
+		@genre = create(:genre)
+	end
+	it "商品の一覧画面を表示できる" do
 		get products_path
 		expect(response).to have_http_status(200)
 	end
-	it "商品の詳細画面を表示" do
-		@product = create(:product)
+	it "商品の詳細画面を表示できる" do
+		@product = create(:product, genre_id: @genre.id)
 		get products_path(@product)
 		expect(response).to have_http_status(200)
 	end

--- a/spec/requests/recipes_spec.rb
+++ b/spec/requests/recipes_spec.rb
@@ -1,6 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe "Recipes", type: :request do
+	it "レシピの一覧画面が表示できる" do
+		get recipes_path
+		expect(response).to have_http_status(200)
+	end
+
 	context "ログインが必要なリクエスト" do
 		before do
 		  	@customer = create(:customer)
@@ -11,9 +16,20 @@ RSpec.describe "Recipes", type: :request do
 			get new_recipe_path
 			expect(response).to have_http_status(200)
 		end
-		it "レシピの新規作成ができる" do
+		it "レシピの新規作成リクエストが成功する" do
 			post recipes_path, params: { recipe: FactoryBot.attributes_for(:recipe) }
 			expect(response).to have_http_status(302)
+		end
+		it "レシピが1件増える" do
+	        expect do
+				post recipes_path, params: { recipe: FactoryBot.attributes_for(:recipe) }
+	        end.to change(Recipe, :count).by(1)
+		end
+
+		it "値が正しくない場合、レシピが新規作成されない" do
+	        expect do
+	          post recipes_path, params: { recipe: FactoryBot.attributes_for(:recipe, title: nil) }
+	        end.to_not change(Recipe, :count)
 		end
 
 		context "レシピが必要なリクエスト" do
@@ -25,28 +41,35 @@ RSpec.describe "Recipes", type: :request do
 				get recipe_path(@recipe)
 				expect(response).to have_http_status(200)
 			end
+
 			it "レシピの編集画面が表示できる" do
 				get edit_recipe_path(@recipe)
 				expect(response).to have_http_status(200)
 			end
-			it "レシピの編集ができる" do
+			it "レシピの更新リクエストが成功する" do
 				put recipe_path(@recipe), params: { recipe: FactoryBot.attributes_for(:recipe) }
-				expect(response).to redirect_to recipe_path(@recipe)
+				expect(response).to have_http_status(302)
+			end
+			it "レシピの更新ができる" do
+				expect do
+					put recipe_path(@recipe), params: { recipe: FactoryBot.attributes_for(:recipe, title: "update-title") }
+				end.to change { Recipe.find(@recipe.id).title }.from(@recipe.title).to("update-title")
+			end
+			it "値が正しくない場合、レシピが更新されない" do
+				expect do
+					put recipe_path(@recipe), params: { recipe: FactoryBot.attributes_for(:recipe, title: nil ) }
+				end.to_not change { Recipe.find(@recipe.id).title }
 			end
 
-			it "レシピの削除ができる" do
+			it "レシピの削除リクエストが成功する" do
 				delete recipe_path(@recipe)
-				expect(response).to redirect_to recipes_path
+				expect(response).to have_http_status(302)
+			end
+			it "レシピが1件減る" do
+		        expect do
+					delete recipe_path(@recipe)
+		        end.to change(Recipe, :count).by(-1)
 			end
 		end
 	end
-
-	it "レシピの一覧画面が表示できる" do
-		get recipes_path
-		expect(response).to have_http_status(200)
-	end
-	it 'Recipesが表示されていること' do
-      get recipes_path
-	  expect(response.body).to include "Recipes"
-    end
 end

--- a/spec/requests/relationships_spec.rb
+++ b/spec/requests/relationships_spec.rb
@@ -15,9 +15,14 @@ RSpec.describe "Relationships", type: :request do
 		expect(response).to have_http_status(200)
 	end
 
-	it "フォローができる" do
+	it "フォローのリクエストが成功する" do
 		post customer_relationships_path(@followed), xhr: true
 		expect(response).to have_http_status(200)
+	end
+	it "フォローが1件増える" do
+		expect do
+			post customer_relationships_path(@followed), xhr: true
+		end.to change(Relationship, :count).by(1)
 	end
 	it "フォロー後、ボタンにフォローをやめるが表示されている" do
 		post customer_relationships_path(@followed), xhr: true
@@ -28,9 +33,14 @@ RSpec.describe "Relationships", type: :request do
 		before do
 			post customer_relationships_path(@followed), xhr: true
 		end
-		it "フォローの解除ができる" do
+		it "フォロー解除のリクエストが成功する" do
 			delete customer_relationships_path(@followed), xhr: true
 			expect(response).to have_http_status(200)
+		end
+		it "フォローが1件減る" do
+			expect do
+				delete customer_relationships_path(@followed), xhr: true
+			end.to change(Relationship, :count).by(-1)
 		end
 		it "フォローの解除後、ボタンにフォローするが表示されている" do
 			delete customer_relationships_path(@followed), xhr: true

--- a/spec/requests/reviews_spec.rb
+++ b/spec/requests/reviews_spec.rb
@@ -5,31 +5,37 @@ RSpec.describe "Reviews", type: :request do
 		@customer = create(:customer, name: "test", postcode: "1234567", address: "test", tel: "11122223333" )
 		sign_in @customer
 		@shipping = create(:shipping, customer_id: @customer.id)
-		@product = create(:product)
+		@genre = create(:genre)
+		@product = create(:product, genre_id: @genre.id)
 		@cart_item = create(:cart_item, customer_id: @customer.id, product_id: @product.id)
 		@order = create(:order, customer_id: @customer.id)
 		@order_detail = create(:order_detail, order_id: @order.id, product_id: @product.id)
 	end
 
-	it "レビューを新規作成できる" do
+	it "レビューの新規作成リクエストが成功する" do
 		post product_reviews_path(@product), params: { review: FactoryBot.attributes_for(:review) }
-		expect(response).to redirect_to product_path(@product)
+		expect(response).to have_http_status(302)
 	end
-	it "レビューが1つ増えている" do
+	it "レビューが1件増える" do
 		expect do
 			post product_reviews_path(@product), params: { review: FactoryBot.attributes_for(:review) }
 		end.to change(Review, :count).by(1)
+	end
+	it "値が正しくない場合、レビューが新規作成されない" do
+        expect do
+          post product_reviews_path(@product), params: { review: FactoryBot.attributes_for(:review, rate: nil) }
+        end.to_not change(Review, :count)
 	end
 
 	context "レビューが必要なリクエスト" do
 		before do
 			@review = create(:review, customer_id: @customer.id, product_id: @product.id)
 		end
-		it "レビューを削除できる" do
+		it "レビューの削除リクエストが成功する" do
 			delete product_review_path(@review, @product)
 			expect(response).to have_http_status(302)
 		end
-		it "レビューが1つ減っている" do
+		it "レビューが1件減る" do
 			expect do
 				delete product_review_path(@review, @product)
 			end.to change(Review, :count).by(-1)

--- a/spec/requests/shippings_spec.rb
+++ b/spec/requests/shippings_spec.rb
@@ -9,9 +9,20 @@ RSpec.describe "Shippings", type: :request do
 		get customers_shippings_path(@customer)
 		expect(response).to have_http_status(200)
 	end
-	it "配送先の新規作成ができる" do
+
+	it "配送先の新規作成リクエストが成功する" do
 		post customers_shippings_path, params: { shipping: FactoryBot.attributes_for(:shipping) }
 		expect(response).to have_http_status(302)
+	end
+	it "配送先が1件増える" do
+        expect do
+			post customers_shippings_path, params: { shipping: FactoryBot.attributes_for(:shipping) }
+        end.to change(Shipping, :count).by(1)
+	end
+	it "値が正しくない場合、配送先が新規作成されない" do
+        expect do
+          post customers_shippings_path, params: { shipping: FactoryBot.attributes_for(:shipping, postcode: 12345678) }
+        end.to_not change(Shipping, :count)
 	end
 
 	context "配送先が必要なリクエスト" do
@@ -23,13 +34,29 @@ RSpec.describe "Shippings", type: :request do
 			get edit_customers_shipping_path(@shipping)
 			expect(response).to have_http_status(200)
 		end
-		it "配送先の編集ができる" do
+		it "配送先の更新リクエストが成功する" do
 			put customers_shipping_path(@shipping), params: { shipping: FactoryBot.attributes_for(:shipping) }
-			expect(response).to redirect_to customers_shippings_path
+			expect(response).to have_http_status(302)
 		end
-		it "配送先の削除ができる" do
+		it "配送先が更新される" do
+			expect do
+				put customers_shipping_path(@shipping), params: { shipping: FactoryBot.attributes_for(:shipping, address: "updata-address") }
+			end.to change { Shipping.find(@shipping.id).address }.from(@shipping.address).to("updata-address")
+		end
+		it "値が正しくない場合、配送先が更新されない" do
+			expect do
+				put customers_shipping_path(@shipping), params: { shipping: FactoryBot.attributes_for(:shipping, address: nil) }
+			end.to_not change { Shipping.find(@shipping.id).address }
+		end
+
+		it "配送先の削除リクエストが成功する" do
 			delete customers_shipping_path(@shipping)
 			expect(response).to redirect_to customers_shippings_path
+		end
+		it "配送先が1件減る" do
+	        expect do
+				delete customers_shipping_path(@shipping)
+	        end.to change(Shipping, :count).by(-1)
 		end
 	end
 end


### PR DESCRIPTION
・リクエスト後のパラメータの妥当/不正のテスト追記
・一部アソシエーションを静的から動的に修正

・配送先作成の失敗後のリダイレクトバグ修正(ページング機能に対応できていなかった)
・注文詳細ページのレイアウト修正