### PR TITLE
クレジット決済(テストモード)導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,3 +93,5 @@ gem 'devise-i18n'
 gem 'devise-i18n-views'
 
 gem 'acts_as_list'
+
+gem 'payjp'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,6 +203,8 @@ GEM
       activerecord (>= 4.0, < 6.1)
     parser (2.7.1.4)
       ast (~> 2.4.1)
+    payjp (0.0.7)
+      rest-client (~> 2.0)
     polyamorous (2.3.2)
       activerecord (>= 5.2.1)
     popper_js (1.16.0)
@@ -387,6 +389,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   mysql2
   paranoia
+  payjp
   pry-byebug
   puma (~> 3.11)
   rails (~> 5.2.4, >= 5.2.4.3)

--- a/app/assets/stylesheets/orders.scss
+++ b/app/assets/stylesheets/orders.scss
@@ -11,6 +11,8 @@
 		height: 70px;
 	}
 }
+
+
 @media screen and (max-width: 959px) {
   /* 959px以下に適用されるCSS（タブレット用） */
   .mr-left{

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -76,12 +76,12 @@ class OrdersController < ApplicationController
         cart_item.destroy
       end
 
-      if @order.payment_method == "クレジットカード"
-        Payjp.api_key = ENV["PAYJP_SECRET_KEY"]
+      if @order.payment_method == 'クレジットカード'
+        Payjp.api_key = ENV['PAYJP_SECRET_KEY']
         Payjp::Charge.create(
-          :amount => @order.total_products_cost + @order.postage ,
-          :card => params['payjp-token'],
-          :currency => 'jpy'
+          amount: @order.total_products_cost + @order.postage,
+          card: params['payjp-token'],
+          currency: 'jpy'
         )
       end
 

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -63,6 +63,7 @@ class OrdersController < ApplicationController
   def create
     @order = Order.new(order_params)
     @order.customer_id = current_customer.id
+
     if @order.save
       cart_items = current_customer.cart_items
       cart_items.each do |cart_item|
@@ -74,6 +75,16 @@ class OrdersController < ApplicationController
         order_detail.save
         cart_item.destroy
       end
+
+      if @order.payment_method == "クレジットカード"
+        Payjp.api_key = ENV["PAYJP_SECRET_KEY"]
+        Payjp::Charge.create(
+          :amount => @order.total_products_cost + @order.postage ,
+          :card => params['payjp-token'],
+          :currency => 'jpy'
+        )
+      end
+
       redirect_to order_complete_path
     else
       redirect_to order_confirm_path

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.13.1/css/all.css" integrity="sha384-xxzQGERXS00kBmZW/6qxqJPyxW3UR0BPsL4c8ILaIWXva5kFi7TxkIIaMiKtqV1Q" crossorigin="anonymous">
     <script type="text/javascript" src="//jpostal-1006.appspot.com/jquery.jpostal.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/sortablejs@latest/Sortable.min.js"></script>
+    <script src="https://js.pay.jp/v2/pay.js"></script>
   </head>
 
   <body style="padding-top:6rem;">

--- a/app/views/orders/confirm.html.erb
+++ b/app/views/orders/confirm.html.erb
@@ -72,14 +72,44 @@
 			</div>
 
 			<div style="text-align: center;">
-				<%= form_with(url: customers_orders_path, local: true) do |f| %>
-				 	<%= f.hidden_field :name, value: @order.name %>
-					<%= f.hidden_field :address, value: @order.address %>
-					<%= f.hidden_field :postcode, value: @order.postcode %>
-					<%= f.hidden_field :postage, value: "800" %>
-					<%= f.hidden_field :total_products_cost, value: @sum %>
-					<%= f.hidden_field :order_status, value: "入金待ち" %>
-				<%= f.submit "注文する", class:"btn btn-warning submit-btn" %>
+				<% if @order.payment_method == "クレジットカード" %>
+					<div style="padding: 20px 0;">
+					<%= form_with local: true, url: customers_orders_path do |f| %>
+					  <script
+					    type="text/javascript"
+					    src="https://checkout.pay.jp"
+					    class="payjp-button"
+					    data-text= "カード情報を入力する"
+					    data-submit-text= "この内容で注文する"
+					    data-key="<%= ENV["PAYJP_PUBLIC_KEY"] %>">
+					  </script>
+					</div>
+					  <div class="font-sm">
+					  	テストモードのため、下記確認し入力して下さい
+					  	<ul style="list-style: none;">
+					  		<li style="color: red">・カード番号：4242424242424242</li>
+					  		<li>・有効期限：未来の年月(12/30)など</li>
+					  		<li>・CVS番号：３桁の任意の数字</li>
+					  		<li>・名前：任意</li>
+					  	</ul>
+					  </div>
+					 	<%= f.hidden_field :name, value: @order.name %>
+						<%= f.hidden_field :address, value: @order.address %>
+						<%= f.hidden_field :postcode, value: @order.postcode %>
+						<%= f.hidden_field :postage, value: "800" %>
+						<%= f.hidden_field :total_products_cost, value: @sum %>
+						<%= f.hidden_field :order_status, value: "入金待ち" %>
+					<% end %>
+				<% else %>
+					<%= form_with(url: customers_orders_path, local: true) do |f| %>
+					 	<%= f.hidden_field :name, value: @order.name %>
+						<%= f.hidden_field :address, value: @order.address %>
+						<%= f.hidden_field :postcode, value: @order.postcode %>
+						<%= f.hidden_field :postage, value: "800" %>
+						<%= f.hidden_field :total_products_cost, value: @sum %>
+						<%= f.hidden_field :order_status, value: "入金待ち" %>
+						<%= f.submit "注文する", class:"btn btn-warning submit-btn" %>
+					<% end %>
 				<% end %>
 			</div>
 		</div>


### PR DESCRIPTION
・PAY.JP追加し、支払い方法をクレジットカード選択時にデモ決済ができるようになった
・注文確定ボタンをクレジットカードと銀行振り込みで分岐