### PR TITLE
ジャンルと製品のリレーションの不具合修正

### DIFF
--- a/app/views/admins/products/index.html.erb
+++ b/app/views/admins/products/index.html.erb
@@ -32,7 +32,11 @@
 						<% end %>
 					</td>
 					<td><%= product.price %>円</td>
-					<td><%= product.genre.name %></td>
+					<%if product.genre %>
+						<td><%= product.genre.name %></td>
+					<% else %>
+						<td>未指定</td>
+					<% end %>
 					<td><%= product.is_active %></td>
 					<td><%= product.reviews.count %>件</td>
 					<td>

--- a/app/views/admins/products/show.html.erb
+++ b/app/views/admins/products/show.html.erb
@@ -44,7 +44,11 @@
                 <p>ジャンル　</p>
               </div>
               <div class="col-lg-9">
+              <%if @product.genre %>
                   <%= @product.genre.name %>
+              <% else %>
+                  <span>未指定</span>
+              <% end %>
               </div>
             </div>
 

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -37,9 +37,13 @@
 			</div>
 			<p style="font-size: 18px;padding: 15px 0 30px 0"><%= @product.introduction %></p>
 			<p class="btn btn-warning btn-sm">
-				<%= link_to products_path(genre_id: @product.genre.id) do %>
-					<%= @product.genre.name %>
-				<% end %>
+			    <%if @product.genre %>
+					<%= link_to products_path(genre_id: @product.genre.id) do %>
+						<%= @product.genre.name %>
+					<% end %>
+					<% else %>
+						未指定
+					<% end %>
 			</p>
 			<span>
 				<p><%= (@product.price * 1.1).to_i %>円(税込)</p>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,209 +10,207 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_10_020431) do
-
-  create_table "admins", force: :cascade do |t|
-    t.string "email", default: "", null: false
-    t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["email"], name: "index_admins_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
+ActiveRecord::Schema.define(version: 20_200_910_020_431) do
+  create_table 'admins', force: :cascade do |t|
+    t.string 'email', default: '', null: false
+    t.string 'encrypted_password', default: '', null: false
+    t.string 'reset_password_token'
+    t.datetime 'reset_password_sent_at'
+    t.datetime 'remember_created_at'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['email'], name: 'index_admins_on_email', unique: true
+    t.index ['reset_password_token'], name: 'index_admins_on_reset_password_token', unique: true
   end
 
-  create_table "cart_items", force: :cascade do |t|
-    t.integer "customer_id"
-    t.integer "product_id"
-    t.integer "count"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+  create_table 'cart_items', force: :cascade do |t|
+    t.integer 'customer_id'
+    t.integer 'product_id'
+    t.integer 'count'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
   end
 
-  create_table "comments", force: :cascade do |t|
-    t.integer "customer_id"
-    t.integer "recipe_id"
-    t.string "content"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+  create_table 'comments', force: :cascade do |t|
+    t.integer 'customer_id'
+    t.integer 'recipe_id'
+    t.string 'content'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
   end
 
-  create_table "cookings", force: :cascade do |t|
-    t.integer "recipe_id"
-    t.string "content"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "position"
+  create_table 'cookings', force: :cascade do |t|
+    t.integer 'recipe_id'
+    t.string 'content'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.integer 'position'
   end
 
-  create_table "customers", force: :cascade do |t|
-    t.string "email", default: "", null: false
-    t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
-    t.string "name"
-    t.string "account_name"
-    t.string "profile_image_id"
-    t.string "tel"
-    t.string "postcode"
-    t.string "address"
-    t.boolean "is_active", default: true
-    t.datetime "deleted_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.text "introduction"
-    t.index ["email"], name: "index_customers_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_customers_on_reset_password_token", unique: true
+  create_table 'customers', force: :cascade do |t|
+    t.string 'email', default: '', null: false
+    t.string 'encrypted_password', default: '', null: false
+    t.string 'reset_password_token'
+    t.datetime 'reset_password_sent_at'
+    t.datetime 'remember_created_at'
+    t.string 'name'
+    t.string 'account_name'
+    t.string 'profile_image_id'
+    t.string 'tel'
+    t.string 'postcode'
+    t.string 'address'
+    t.boolean 'is_active', default: true
+    t.datetime 'deleted_at'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.text 'introduction'
+    t.index ['email'], name: 'index_customers_on_email', unique: true
+    t.index ['reset_password_token'], name: 'index_customers_on_reset_password_token', unique: true
   end
 
-  create_table "favorites", force: :cascade do |t|
-    t.integer "customer_id"
-    t.integer "recipe_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+  create_table 'favorites', force: :cascade do |t|
+    t.integer 'customer_id'
+    t.integer 'recipe_id'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
   end
 
-  create_table "genres", force: :cascade do |t|
-    t.string "name"
-    t.text "introduction"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+  create_table 'genres', force: :cascade do |t|
+    t.string 'name'
+    t.text 'introduction'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
   end
 
-  create_table "impressions", force: :cascade do |t|
-    t.string "impressionable_type"
-    t.integer "impressionable_id"
-    t.integer "user_id"
-    t.string "controller_name"
-    t.string "action_name"
-    t.string "view_name"
-    t.string "request_hash"
-    t.string "ip_address"
-    t.string "session_hash"
-    t.text "message"
-    t.text "referrer"
-    t.text "params"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["controller_name", "action_name", "ip_address"], name: "controlleraction_ip_index"
-    t.index ["controller_name", "action_name", "request_hash"], name: "controlleraction_request_index"
-    t.index ["controller_name", "action_name", "session_hash"], name: "controlleraction_session_index"
-    t.index ["impressionable_type", "impressionable_id", "ip_address"], name: "poly_ip_index"
-    t.index ["impressionable_type", "impressionable_id", "params"], name: "poly_params_request_index"
-    t.index ["impressionable_type", "impressionable_id", "request_hash"], name: "poly_request_index"
-    t.index ["impressionable_type", "impressionable_id", "session_hash"], name: "poly_session_index"
-    t.index ["impressionable_type", "message", "impressionable_id"], name: "impressionable_type_message_index"
-    t.index ["user_id"], name: "index_impressions_on_user_id"
+  create_table 'impressions', force: :cascade do |t|
+    t.string 'impressionable_type'
+    t.integer 'impressionable_id'
+    t.integer 'user_id'
+    t.string 'controller_name'
+    t.string 'action_name'
+    t.string 'view_name'
+    t.string 'request_hash'
+    t.string 'ip_address'
+    t.string 'session_hash'
+    t.text 'message'
+    t.text 'referrer'
+    t.text 'params'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index %w[controller_name action_name ip_address], name: 'controlleraction_ip_index'
+    t.index %w[controller_name action_name request_hash], name: 'controlleraction_request_index'
+    t.index %w[controller_name action_name session_hash], name: 'controlleraction_session_index'
+    t.index %w[impressionable_type impressionable_id ip_address], name: 'poly_ip_index'
+    t.index %w[impressionable_type impressionable_id params], name: 'poly_params_request_index'
+    t.index %w[impressionable_type impressionable_id request_hash], name: 'poly_request_index'
+    t.index %w[impressionable_type impressionable_id session_hash], name: 'poly_session_index'
+    t.index %w[impressionable_type message impressionable_id], name: 'impressionable_type_message_index'
+    t.index ['user_id'], name: 'index_impressions_on_user_id'
   end
 
-  create_table "ingredients", force: :cascade do |t|
-    t.integer "recipe_id"
-    t.string "content"
-    t.string "amount"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "position"
+  create_table 'ingredients', force: :cascade do |t|
+    t.integer 'recipe_id'
+    t.string 'content'
+    t.string 'amount'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.integer 'position'
   end
 
-  create_table "order_details", force: :cascade do |t|
-    t.integer "product_id"
-    t.integer "order_id"
-    t.integer "count"
-    t.integer "price"
-    t.integer "work_status"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+  create_table 'order_details', force: :cascade do |t|
+    t.integer 'product_id'
+    t.integer 'order_id'
+    t.integer 'count'
+    t.integer 'price'
+    t.integer 'work_status'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
   end
 
-  create_table "orders", force: :cascade do |t|
-    t.integer "customer_id"
-    t.string "name"
-    t.string "postcode"
-    t.string "address"
-    t.integer "postage"
-    t.integer "total_products_cost"
-    t.boolean "payment_method", default: true
-    t.integer "order_status"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+  create_table 'orders', force: :cascade do |t|
+    t.integer 'customer_id'
+    t.string 'name'
+    t.string 'postcode'
+    t.string 'address'
+    t.integer 'postage'
+    t.integer 'total_products_cost'
+    t.boolean 'payment_method', default: true
+    t.integer 'order_status'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
   end
 
-  create_table "products", force: :cascade do |t|
-    t.integer "genre_id"
-    t.string "name"
-    t.integer "price"
-    t.text "introduction"
-    t.string "product_image_id"
-    t.boolean "is_active", default: true
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+  create_table 'products', force: :cascade do |t|
+    t.integer 'genre_id'
+    t.string 'name'
+    t.integer 'price'
+    t.text 'introduction'
+    t.string 'product_image_id'
+    t.boolean 'is_active', default: true
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
   end
 
-  create_table "recipes", force: :cascade do |t|
-    t.integer "customer_id"
-    t.string "title"
-    t.text "introduction"
-    t.string "recipe_image_id"
-    t.string "amount"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "recipe_status"
-    t.integer "impressions_count", default: 0
+  create_table 'recipes', force: :cascade do |t|
+    t.integer 'customer_id'
+    t.string 'title'
+    t.text 'introduction'
+    t.string 'recipe_image_id'
+    t.string 'amount'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.integer 'recipe_status'
+    t.integer 'impressions_count', default: 0
   end
 
-  create_table "relationships", force: :cascade do |t|
-    t.integer "follower_id"
-    t.integer "followed_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+  create_table 'relationships', force: :cascade do |t|
+    t.integer 'follower_id'
+    t.integer 'followed_id'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
   end
 
-  create_table "reviews", force: :cascade do |t|
-    t.integer "product_id"
-    t.integer "customer_id"
-    t.float "rate"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.text "content"
-    t.decimal "score", precision: 5, scale: 3
+  create_table 'reviews', force: :cascade do |t|
+    t.integer 'product_id'
+    t.integer 'customer_id'
+    t.float 'rate'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.text 'content'
+    t.decimal 'score', precision: 5, scale: 3
   end
 
-  create_table "shippings", force: :cascade do |t|
-    t.integer "customer_id"
-    t.string "name"
-    t.string "postcode"
-    t.string "address"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+  create_table 'shippings', force: :cascade do |t|
+    t.integer 'customer_id'
+    t.string 'name'
+    t.string 'postcode'
+    t.string 'address'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
   end
 
-  create_table "taggings", force: :cascade do |t|
-    t.integer "tag_id"
-    t.string "taggable_type"
-    t.integer "taggable_id"
-    t.string "tagger_type"
-    t.integer "tagger_id"
-    t.string "context", limit: 128
-    t.datetime "created_at"
-    t.index ["context"], name: "index_taggings_on_context"
-    t.index ["tag_id"], name: "index_taggings_on_tag_id"
-    t.index ["taggable_id", "taggable_type", "context"], name: "taggings_taggable_context_idx"
-    t.index ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy"
-    t.index ["taggable_id"], name: "index_taggings_on_taggable_id"
-    t.index ["taggable_type"], name: "index_taggings_on_taggable_type"
-    t.index ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type"
-    t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
+  create_table 'taggings', force: :cascade do |t|
+    t.integer 'tag_id'
+    t.string 'taggable_type'
+    t.integer 'taggable_id'
+    t.string 'tagger_type'
+    t.integer 'tagger_id'
+    t.string 'context', limit: 128
+    t.datetime 'created_at'
+    t.index ['context'], name: 'index_taggings_on_context'
+    t.index ['tag_id'], name: 'index_taggings_on_tag_id'
+    t.index %w[taggable_id taggable_type context], name: 'taggings_taggable_context_idx'
+    t.index %w[taggable_id taggable_type tagger_id context], name: 'taggings_idy'
+    t.index ['taggable_id'], name: 'index_taggings_on_taggable_id'
+    t.index ['taggable_type'], name: 'index_taggings_on_taggable_type'
+    t.index %w[tagger_id tagger_type], name: 'index_taggings_on_tagger_id_and_tagger_type'
+    t.index ['tagger_id'], name: 'index_taggings_on_tagger_id'
   end
 
-  create_table "tags", force: :cascade do |t|
-    t.string "name"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.integer "taggings_count", default: 0
+  create_table 'tags', force: :cascade do |t|
+    t.string 'name'
+    t.datetime 'created_at'
+    t.datetime 'updated_at'
+    t.integer 'taggings_count', default: 0
   end
-
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,207 +10,209 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_200_910_020_431) do
-  create_table 'admins', force: :cascade do |t|
-    t.string 'email', default: '', null: false
-    t.string 'encrypted_password', default: '', null: false
-    t.string 'reset_password_token'
-    t.datetime 'reset_password_sent_at'
-    t.datetime 'remember_created_at'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['email'], name: 'index_admins_on_email', unique: true
-    t.index ['reset_password_token'], name: 'index_admins_on_reset_password_token', unique: true
+ActiveRecord::Schema.define(version: 2020_09_10_020431) do
+
+  create_table "admins", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_admins_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
   end
 
-  create_table 'cart_items', force: :cascade do |t|
-    t.integer 'customer_id'
-    t.integer 'product_id'
-    t.integer 'count'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "cart_items", force: :cascade do |t|
+    t.integer "customer_id"
+    t.integer "product_id"
+    t.integer "count"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table 'comments', force: :cascade do |t|
-    t.integer 'customer_id'
-    t.integer 'recipe_id'
-    t.string 'content'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "comments", force: :cascade do |t|
+    t.integer "customer_id"
+    t.integer "recipe_id"
+    t.string "content"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table 'cookings', force: :cascade do |t|
-    t.integer 'recipe_id'
-    t.string 'content'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.integer 'position'
+  create_table "cookings", force: :cascade do |t|
+    t.integer "recipe_id"
+    t.string "content"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "position"
   end
 
-  create_table 'customers', force: :cascade do |t|
-    t.string 'email', default: '', null: false
-    t.string 'encrypted_password', default: '', null: false
-    t.string 'reset_password_token'
-    t.datetime 'reset_password_sent_at'
-    t.datetime 'remember_created_at'
-    t.string 'name'
-    t.string 'account_name'
-    t.string 'profile_image_id'
-    t.string 'tel'
-    t.string 'postcode'
-    t.string 'address'
-    t.boolean 'is_active', default: true
-    t.datetime 'deleted_at'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.text 'introduction'
-    t.index ['email'], name: 'index_customers_on_email', unique: true
-    t.index ['reset_password_token'], name: 'index_customers_on_reset_password_token', unique: true
+  create_table "customers", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.string "name"
+    t.string "account_name"
+    t.string "profile_image_id"
+    t.string "tel"
+    t.string "postcode"
+    t.string "address"
+    t.boolean "is_active", default: true
+    t.datetime "deleted_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.text "introduction"
+    t.index ["email"], name: "index_customers_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_customers_on_reset_password_token", unique: true
   end
 
-  create_table 'favorites', force: :cascade do |t|
-    t.integer 'customer_id'
-    t.integer 'recipe_id'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "favorites", force: :cascade do |t|
+    t.integer "customer_id"
+    t.integer "recipe_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table 'genres', force: :cascade do |t|
-    t.string 'name'
-    t.text 'introduction'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "genres", force: :cascade do |t|
+    t.string "name"
+    t.text "introduction"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table 'impressions', force: :cascade do |t|
-    t.string 'impressionable_type'
-    t.integer 'impressionable_id'
-    t.integer 'user_id'
-    t.string 'controller_name'
-    t.string 'action_name'
-    t.string 'view_name'
-    t.string 'request_hash'
-    t.string 'ip_address'
-    t.string 'session_hash'
-    t.text 'message'
-    t.text 'referrer'
-    t.text 'params'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index %w[controller_name action_name ip_address], name: 'controlleraction_ip_index'
-    t.index %w[controller_name action_name request_hash], name: 'controlleraction_request_index'
-    t.index %w[controller_name action_name session_hash], name: 'controlleraction_session_index'
-    t.index %w[impressionable_type impressionable_id ip_address], name: 'poly_ip_index'
-    t.index %w[impressionable_type impressionable_id params], name: 'poly_params_request_index'
-    t.index %w[impressionable_type impressionable_id request_hash], name: 'poly_request_index'
-    t.index %w[impressionable_type impressionable_id session_hash], name: 'poly_session_index'
-    t.index %w[impressionable_type message impressionable_id], name: 'impressionable_type_message_index'
-    t.index ['user_id'], name: 'index_impressions_on_user_id'
+  create_table "impressions", force: :cascade do |t|
+    t.string "impressionable_type"
+    t.integer "impressionable_id"
+    t.integer "user_id"
+    t.string "controller_name"
+    t.string "action_name"
+    t.string "view_name"
+    t.string "request_hash"
+    t.string "ip_address"
+    t.string "session_hash"
+    t.text "message"
+    t.text "referrer"
+    t.text "params"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["controller_name", "action_name", "ip_address"], name: "controlleraction_ip_index"
+    t.index ["controller_name", "action_name", "request_hash"], name: "controlleraction_request_index"
+    t.index ["controller_name", "action_name", "session_hash"], name: "controlleraction_session_index"
+    t.index ["impressionable_type", "impressionable_id", "ip_address"], name: "poly_ip_index"
+    t.index ["impressionable_type", "impressionable_id", "params"], name: "poly_params_request_index"
+    t.index ["impressionable_type", "impressionable_id", "request_hash"], name: "poly_request_index"
+    t.index ["impressionable_type", "impressionable_id", "session_hash"], name: "poly_session_index"
+    t.index ["impressionable_type", "message", "impressionable_id"], name: "impressionable_type_message_index"
+    t.index ["user_id"], name: "index_impressions_on_user_id"
   end
 
-  create_table 'ingredients', force: :cascade do |t|
-    t.integer 'recipe_id'
-    t.string 'content'
-    t.string 'amount'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.integer 'position'
+  create_table "ingredients", force: :cascade do |t|
+    t.integer "recipe_id"
+    t.string "content"
+    t.string "amount"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "position"
   end
 
-  create_table 'order_details', force: :cascade do |t|
-    t.integer 'product_id'
-    t.integer 'order_id'
-    t.integer 'count'
-    t.integer 'price'
-    t.integer 'work_status'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "order_details", force: :cascade do |t|
+    t.integer "product_id"
+    t.integer "order_id"
+    t.integer "count"
+    t.integer "price"
+    t.integer "work_status"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table 'orders', force: :cascade do |t|
-    t.integer 'customer_id'
-    t.string 'name'
-    t.string 'postcode'
-    t.string 'address'
-    t.integer 'postage'
-    t.integer 'total_products_cost'
-    t.boolean 'payment_method', default: true
-    t.integer 'order_status'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "orders", force: :cascade do |t|
+    t.integer "customer_id"
+    t.string "name"
+    t.string "postcode"
+    t.string "address"
+    t.integer "postage"
+    t.integer "total_products_cost"
+    t.boolean "payment_method", default: true
+    t.integer "order_status"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table 'products', force: :cascade do |t|
-    t.integer 'genre_id'
-    t.string 'name'
-    t.integer 'price'
-    t.text 'introduction'
-    t.string 'product_image_id'
-    t.boolean 'is_active', default: true
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "products", force: :cascade do |t|
+    t.integer "genre_id"
+    t.string "name"
+    t.integer "price"
+    t.text "introduction"
+    t.string "product_image_id"
+    t.boolean "is_active", default: true
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table 'recipes', force: :cascade do |t|
-    t.integer 'customer_id'
-    t.string 'title'
-    t.text 'introduction'
-    t.string 'recipe_image_id'
-    t.string 'amount'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.integer 'recipe_status'
-    t.integer 'impressions_count', default: 0
+  create_table "recipes", force: :cascade do |t|
+    t.integer "customer_id"
+    t.string "title"
+    t.text "introduction"
+    t.string "recipe_image_id"
+    t.string "amount"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "recipe_status"
+    t.integer "impressions_count", default: 0
   end
 
-  create_table 'relationships', force: :cascade do |t|
-    t.integer 'follower_id'
-    t.integer 'followed_id'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "relationships", force: :cascade do |t|
+    t.integer "follower_id"
+    t.integer "followed_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table 'reviews', force: :cascade do |t|
-    t.integer 'product_id'
-    t.integer 'customer_id'
-    t.float 'rate'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.text 'content'
-    t.decimal 'score', precision: 5, scale: 3
+  create_table "reviews", force: :cascade do |t|
+    t.integer "product_id"
+    t.integer "customer_id"
+    t.float "rate"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.text "content"
+    t.decimal "score", precision: 5, scale: 3
   end
 
-  create_table 'shippings', force: :cascade do |t|
-    t.integer 'customer_id'
-    t.string 'name'
-    t.string 'postcode'
-    t.string 'address'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "shippings", force: :cascade do |t|
+    t.integer "customer_id"
+    t.string "name"
+    t.string "postcode"
+    t.string "address"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table 'taggings', force: :cascade do |t|
-    t.integer 'tag_id'
-    t.string 'taggable_type'
-    t.integer 'taggable_id'
-    t.string 'tagger_type'
-    t.integer 'tagger_id'
-    t.string 'context', limit: 128
-    t.datetime 'created_at'
-    t.index ['context'], name: 'index_taggings_on_context'
-    t.index ['tag_id'], name: 'index_taggings_on_tag_id'
-    t.index %w[taggable_id taggable_type context], name: 'taggings_taggable_context_idx'
-    t.index %w[taggable_id taggable_type tagger_id context], name: 'taggings_idy'
-    t.index ['taggable_id'], name: 'index_taggings_on_taggable_id'
-    t.index ['taggable_type'], name: 'index_taggings_on_taggable_type'
-    t.index %w[tagger_id tagger_type], name: 'index_taggings_on_tagger_id_and_tagger_type'
-    t.index ['tagger_id'], name: 'index_taggings_on_tagger_id'
+  create_table "taggings", force: :cascade do |t|
+    t.integer "tag_id"
+    t.string "taggable_type"
+    t.integer "taggable_id"
+    t.string "tagger_type"
+    t.integer "tagger_id"
+    t.string "context", limit: 128
+    t.datetime "created_at"
+    t.index ["context"], name: "index_taggings_on_context"
+    t.index ["tag_id"], name: "index_taggings_on_tag_id"
+    t.index ["taggable_id", "taggable_type", "context"], name: "taggings_taggable_context_idx"
+    t.index ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy"
+    t.index ["taggable_id"], name: "index_taggings_on_taggable_id"
+    t.index ["taggable_type"], name: "index_taggings_on_taggable_type"
+    t.index ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type"
+    t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
   end
 
-  create_table 'tags', force: :cascade do |t|
-    t.string 'name'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
-    t.integer 'taggings_count', default: 0
+  create_table "tags", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer "taggings_count", default: 0
   end
+
 end


### PR DESCRIPTION
・dependent: :destroyがついておらず、ジャンル削除時に製品だけが残り正しく表示できていなかった
・ジャンル削除時に合わせて消すのではなく、未選択状態に変更し製品は残して別のジャンルを選択できるように修正